### PR TITLE
Add keyboard navigation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,11 @@
 		"default_icon": "icon.png",
 		"default_title": "Volume Control",
 		"default_popup": "popup.html"
+	},
+
+	"commands": {
+		"_execute_browser_action": {
+			"description": "Open volume control"
+		}
 	}
 }

--- a/popup.js
+++ b/popup.js
@@ -1,3 +1,5 @@
+document.querySelector("#volume-slider").focus();
+
 function listenForEvents() {
 	function err(error) {
 		console.error(`Volume Control: Error: ${error}`);


### PR DESCRIPTION
- Add command for opening the popup
- Automatically focus the volume slider when opening the popup, meaning the arrow keys can immediately be used when opened

This improves accessibility and enables use as a power tool, with no negative impact on other use cases.