### PR TITLE
fix when audio starts muted

### DIFF
--- a/cs.js
+++ b/cs.js
@@ -65,6 +65,12 @@ function init(document){
     connectOutput(newElem);
   });
 
+  document.addEventListener("click", function () {
+    if (tc.vars.audioCtx.state === "suspended") {
+      tc.vars.audioCtx.resume();
+    }
+  });
+
   browser.runtime.onMessage.addListener((message) => {
     switch (message.command) {
       case "setVolume":

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Volume Control",
-  "version": "2.4",
+  "version": "2.4.1",
   "description": "Adds a volume control for the current site, that can also boost the volume beyond the normal range.",
   "homepage_url": "https://github.com/Chaython/volumecontrol",
   "icons": {


### PR DESCRIPTION
Hi,
I fixed an issue with audio context that prevents to hear the audio when a video starts with the audio muted.
For example with [this facebook video](https://www.facebook.com/NickelodeonAustralia/videos/636341373897057/?extid=CL-UNK-UNK-UNK-AN_GK0T-GK1C&mibextid=2Rb1fB&ref=sharing) you were unable to hear the audio.

With this fix you should hear the audio as expected!

Regards