### PR TITLE
Update _execute_browser_action to _execute_action

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
     }
   ],
   "commands": {
-    "_execute_browser_action": {
+    "_execute_action": {
       "description": "Open volume control"
     }
   },


### PR DESCRIPTION
- The browser action and page action APIs, and their corresponding manifest command keys, were consolidated into simply "action" in MV3

Thanks for your work on improving the usability of this extension :heart: 