### PR TITLE
Add blacklist alert toggle add wildcards support to blacklist

### DIFF
--- a/options.css
+++ b/options.css
@@ -1,5 +1,26 @@
+body {
+	font-family: Seravek, 'Gill Sans Nova', Ubuntu, Calibri, 'DejaVu Sans', source-sans-pro, sans-serif;
+	font-weight: normal;
+}
+
+@media (prefers-color-scheme: dark) {
+	body, input, button {
+		color: #fff;
+		background-color: #23222b;
+	}
+}
+
+input, button {
+	border: 1px solid #888;
+}
+
 .remove-entry {
 	color: red;
 	padding-left: 5px;
 	cursor: pointer;
+}
+
+.container {
+	display: block;
+	margin-bottom: 8px;
 }

--- a/options.html
+++ b/options.html
@@ -1,14 +1,19 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <link rel="stylesheet" href="options.css"/>
-    </head>
+<head>
+    <link rel="stylesheet" href="options.css"/>
+</head>
 <body>
     <div id="settings-content" class="center">
-        <input type="text" id="newFqdn" placeholder="Blacklist a site">
-        <button id="addFqdn">Add</button>
+        <div class="container">
+            <input type="checkbox" name="Disable blacklist alert" id="disable-blacklist-alert-option">Disable blacklist alert
+        </div>
+        <div class="container">
+            <input type="text" id="newFqdn" placeholder="Blacklist a site">
+            <button id="addFqdn">Add</button>
+        </div>
         <div id="fqdnList" class="fqdn-box"></div>
-    </div>    
-<script src="cs.js"></script>
+    </div>
+    <script src="cs.js"></script>
 </body>
 </html>


### PR DESCRIPTION
- Added option to disable blacklist alert
- Added dark mode to options page

![image](https://github.com/user-attachments/assets/6f17a110-0cad-4e10-8625-1e6749ead248)

- Added wildcard support to domain names

Whenever viewing clips on twitch, this extension breaks the audio. I'd like to be able to disable this extension for all subdomains of twitch by adding `*.twitch.tv` to the blacklist.

- Removed URL normalization

I removed it because it could result in urls being saved like this:
![image](https://github.com/user-attachments/assets/c4dd8f51-e341-41a5-a30f-3be475a42560)

- Updated accepted fqdn regex

There could be cases that this regex actually rejects working urls. Some real world examples are https://off---white.com and https://about.google. The new regex is more flexible and also accepts wildcard asterisks.

- Cleaned up stray console errors