### PR TITLE
add listener to focus slider on any key press

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -67,6 +67,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (message.type === "exclusion") showError({ type: "exclusion" });
   });
 
+  document.addEventListener('keydown', () => {
+    if (slider && document.activeElement !== slider) {
+      slider.focus();
+    }
+  }, { once: true });
+
   listenForEvents();
 });
 


### PR DESCRIPTION
The existing version tries to slider.focus() but something seems to steal focus afterwards. This just adds a listener to focus the slider on the first keypress after the popup loads, allowing immediate changes to volume with the arrow keys.